### PR TITLE
Add random meme words and make images round

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,11 @@
   }
   .memes img {
     width: 100%;
-    border-radius: 8px;
+    border-radius: 50%;
+    transition: transform 0.3s;
+  }
+  .memes img:hover {
+    transform: scale(1.1) rotate(-5deg);
   }
   .tagline {
     text-align: center;
@@ -59,12 +63,15 @@
     "cbg","center","ch","chair","cheems","chosen","cmm","country",
     "crazypills","crow","cryingfloor","db","dbg"
   ];
+  const words = [
+    'кит','ёжик','утюг','лампа','медведь','пицца','робот','кактус'
+  ];
   const container = document.getElementById('memes');
   for(let i = 1; i <= 100; i++) {
     const img = new Image();
-    const template = templates[(i - 1) % templates.length];
-    const top = `терка ${i}`;
-    const bottom = 'атата';
+    const template = templates[Math.floor(Math.random() * templates.length)];
+    const top = `${words[Math.floor(Math.random() * words.length)]} ${i}`;
+    const bottom = words[Math.floor(Math.random() * words.length)];
     const ext = (i % 10 === 0) ? 'gif' : 'png';
     img.src = `https://api.memegen.link/images/${template}/${encodeURIComponent(top)}/${encodeURIComponent(bottom)}.${ext}`;
     img.alt = `meme ${i}`;


### PR DESCRIPTION
## Summary
- make meme images round with a hover effect
- randomize meme templates and text on each page load

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b8043cfbc8323a626d0b735f7a9c2